### PR TITLE
[add]弁当箱の中身をlocalstorageへ保存

### DIFF
--- a/lib/lunchBox.js
+++ b/lib/lunchBox.js
@@ -43,7 +43,7 @@ export function initGuzaiInLunchBox() {
     for (let i = 0; i < lunchBoxLength; i++) {
         initData.push(null);
     }
-    addGuzaiInLunchBox(initData);
+    localStorage.setItem(key, JSON.stringify(initData));
 }
 
 export function deleteGuzaiInLunchBox() {


### PR DESCRIPTION
## 変更内容
弁当箱の中身（具材のidの配列）をlocalstorageに保存するライブラリを追加しました。

## 説明
弁当箱を９分割することにしました。
以下の3×3のマス目に分割しようと思っています。（番号は後に出てくるplaceNumberに対応）

0 　1 　2　（奥）
3 　4 　5
6 　7 　8　（手前）

この場所の番号順にidを並べたものをlocalstorageに保存。

関数addGuzaiInLunchBoxでは、具材のidとplaceNumberを受け取って具材を弁当箱へ追加する。
placeNumberは「どこに入れる？」でプレイヤーが選択した弁当箱の場所の数字を入れたい。